### PR TITLE
add `-I .` to CYTHONFLAGS to fix `pxd not found`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CXXFLAGS=-std=c++11 -Wall -Wextra -pedantic -fPIC -O1 -g -I$(PYTHONINCDIR)
 LDFLAGS=--shared
 MODLDFLAGS=
 CYTHON=cython
-CYTHONFLAGS=--gdb --cplus -3 --fast-fail
+CYTHONFLAGS=--gdb --cplus -3 --fast-fail -I .
 PXDGEN=python3 pxdgen.py
 
 .PHONY: all


### PR DESCRIPTION
```
Python 3.5.1
Cython version 0.23.4
```

I don't know if this is related to a particular version of python/cython

I also switched the `PYTHON` var to `3.5m` to reflect my system (should I push that too?)
